### PR TITLE
Remove async keyword from handleObservationExtract button click

### DIFF
--- a/apps/smart-forms-app/src/features/playground/components/Playground.tsx
+++ b/apps/smart-forms-app/src/features/playground/components/Playground.tsx
@@ -154,7 +154,7 @@ function Playground() {
   }
 
   // Observation $extract
-  async function handleObservationExtract() {
+  function handleObservationExtract() {
     const observations = extractObservationBased(sourceQuestionnaire, updatableResponse);
     setExtractedResource(observations);
 


### PR DESCRIPTION
Hi @ryuuzake,

Just making a small change re my comment in https://github.com/aehrc/smart-forms/pull/988.

Feel free to just make the change on your side (and close the issue) so we don't need to go through the merging dance again.

Thanks!